### PR TITLE
Add optional NextUI Setup Wizard information to the "What You Will Need" section

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -20,3 +20,10 @@
 - The latest release of NextUI from the [GitHub Repo :simple-github:]({{ urls.github }}/releases).
     - At minimum, you will need the `base.zip` file.
     - If you want additional goodies, download `extras.zip` as well (or download `all.zip` to get both files in one).
+
+#### [Optional]
+
+- The community made [NextUI Setup Wizard](https://github.com/aaronhoogstraten/NextUI-Setup-Wizard) for Windows and macOS provides an easy to use interface for performing the setup of your NextUI device, including:
+    - Micro SD card formatting instructions
+    - Latest NextUI release download and installation to micro SD card
+    - ROM and BIOS setup instructions for popular systems


### PR DESCRIPTION
Proposal to add a link to my NextUI Setup Wizard to the official docs. I do not feel strongly at all about adding this, just piggy backing off my other PR to add the MBR info since we're still seeing some people come into discord with improperly formatted SD cards.

Besides savant and K-Wall, I know of 2 users that have successfully used the setup wizard, but otherwise there hasn't been much visibility of the wizard to attract more users to see if it helps reduce the amount SD card formatting troubleshooting questions.